### PR TITLE
feat: Add PCA analysis feature

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -9,3 +9,4 @@ dependencies:
   - pandas=1.3.5
   - python=3.10.2
   - python-kaleido
+  - scikit-learn


### PR DESCRIPTION
This commit introduces the ability to perform PCA on the growth curve data.

- Adds a `--pca` flag to enable the feature.
- Adds a `--pca_color` flag to specify the variable to color the PCA plot by.
- Performs PCA on the smoothed data.
- Generates a scores plot of the first two principal components.
- Saves the plot to a new `PCA` directory within the `Plots` directory.